### PR TITLE
Bump dependencies to work with newer kubernetes+helm

### DIFF
--- a/chart/brigdrake/requirements.lock
+++ b/chart/brigdrake/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: nfs-server-provisioner
-  repository: https://kubernetes-charts.storage.googleapis.com
-  version: 0.3.0
+  repository: https://charts.helm.sh/stable
+  version: 1.1.3
 - name: brigade
   repository: https://brigadecore.github.io/charts
-  version: 1.3.1
-digest: sha256:2853657210e3386e7acd5750b04e20c77b9a46dd7d0a84c383951a60a4ee2ee5
-generated: "2019-10-30T15:59:21.194369-04:00"
+  version: 1.8.0
+digest: sha256:d1c539c7f4ad9e4445381b87704f6e6ed5463b061d9cbf38c0713ba6560f18b0
+generated: "2021-04-02T12:10:06.008839-05:00"

--- a/chart/brigdrake/requirements.yaml
+++ b/chart/brigdrake/requirements.yaml
@@ -2,8 +2,8 @@ dependencies:
   - name: nfs-server-provisioner
     alias: nfs
     version: 0.3.0
-    repository: https://kubernetes-charts.storage.googleapis.com
+    repository: https://charts.helm.sh/stable
     condition: nfs.enabled
   - name: brigade
-    version: 1.3.1
+    version: 1.8.0
     repository: https://brigadecore.github.io/charts


### PR DESCRIPTION
* Use a version of the charts that doesn't use deprecated api versions