### PR TITLE
fix verify-vendored-code

### DIFF
--- a/Drakefile.yaml
+++ b/Drakefile.yaml
@@ -58,6 +58,7 @@ jobs:
     primaryContainer:
       <<: *baseGoContainer
       command: ["go", "run", "mage.go", "verifyVendor"]
+    sourceMountMode: COPY
 
   test-unit:
     primaryContainer:


### PR DESCRIPTION
Jobs aren't meant to modify source code _unless_ source mount mode is `RW` or `COPY`.

I think we're likely to revisit this part of the spec later, but the rationale behind it was that every job should receive what it can (by default) assume to be pristine, unaltered source code.

Since this job potentially alters the `vendor/` dir, it needs a copy of the source.