### PR TITLE
Publish worker on release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,9 +9,28 @@ jobs:
       - run: go run mage.go -v test
       - run: bash <(curl -s https://codecov.io/bash)
       - run: go run mage.go -v lint
+  publish:
+    docker:
+      - image: krancour/dind:18.09.5
+        user: root
+    steps:
+      - setup_remote_docker:
+          version: 19.03.13
+      - checkout
+      - run: scripts/build-and-publish-worker-dood.sh
+
 
 workflows:
   version: 2
-  build-workflow:
+  build:
     jobs:
       - test
+      - publish:
+          requires:
+            - test
+          context:
+            - prod
+          filters:
+            branches:
+              only:
+                - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,3 +34,4 @@ workflows:
             branches:
               only:
                 - master
+                - testci

--- a/magefile.go
+++ b/magefile.go
@@ -33,6 +33,10 @@ func Build() {
 		"brigadecore/go-tools:v0.1.0", "scripts/build-worker-binary.sh", runtime.GOOS, runtime.GOARCH)
 }
 
+func BuildImage() {
+	must.RunV("./scripts/build-worker-dood.sh")
+}
+
 // Run go tests
 func Test() {
 	coverageFile := filepath.Join(mage.GetOutputDir(), "coverage.txt")

--- a/scripts/base-docker.sh
+++ b/scripts/base-docker.sh
@@ -1,21 +1,17 @@
 #!/bin/sh
 
-set -eo pipefail
+set -euo pipefail
 
-set +u # Some vars may be unbound-- that's ok here
+DOCKER_REGISTRY=${DOCKER_REGISTRY:-ghcr.io}
+DOCKER_REGISTRY_NAMESPACE=${DOCKER_REGISTRY_NAMESPACE:-lovethedrake}
 
-if [ "$DOCKER_REGISTRY" == "" ]; then
-  docker_registry=""
-else
-  docker_registry=$DOCKER_REGISTRY/
+# Append a trailing slash if set
+if [ "$DOCKER_REGISTRY" != "" ]; then
+  DOCKER_REGISTRY=$DOCKER_REGISTRY/
 fi
 
-if [ "$DOCKER_REGISTRY_NAMESPACE" == "" ]; then
-  docker_registry_namespace=""
-else
-  docker_registry_namespace=$DOCKER_REGISTRY_NAMESPACE/
+if [ "$DOCKER_REGISTRY_NAMESPACE" != "" ]; then
+  DOCKER_REGISTRY_NAMESPACE=$DOCKER_REGISTRY_NAMESPACE/
 fi
 
-set -u
-
-export base_image_name=${docker_registry}${docker_registry_namespace}brigdrake-worker
+export base_image_name=${DOCKER_REGISTRY}${DOCKER_REGISTRY_NAMESPACE}brigdrake-worker

--- a/scripts/base-docker.sh
+++ b/scripts/base-docker.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-DOCKER_REGISTRY=${DOCKER_REGISTRY:-ghcr.io}
+export DOCKER_REGISTRY=${DOCKER_REGISTRY:-ghcr.io}
 DOCKER_REGISTRY_NAMESPACE=${DOCKER_REGISTRY_NAMESPACE:-lovethedrake}
 
 # Append a trailing slash if set
@@ -14,4 +14,4 @@ if [ "$DOCKER_REGISTRY_NAMESPACE" != "" ]; then
   DOCKER_REGISTRY_NAMESPACE=$DOCKER_REGISTRY_NAMESPACE/
 fi
 
-export base_image_name=${DOCKER_REGISTRY}${DOCKER_REGISTRY_NAMESPACE}brigdrake-worker
+export BASE_IMAGE_NAME=${DOCKER_REGISTRY}${DOCKER_REGISTRY_NAMESPACE}brigdrake-worker

--- a/scripts/build-and-publish-worker-dind.sh
+++ b/scripts/build-and-publish-worker-dind.sh
@@ -27,9 +27,5 @@ dockerd \
 # Wait for the containerized dockerd to be ready
 scripts/wupiao.sh localhost 2375 300
 
-set +x # Don't let the value of $DOCKER_PASSWORD bleed into the logs!
-docker login -u krancour -p $DOCKER_PASSWORD
-set -x
-
 scripts/docker-build.sh
 scripts/docker-publish.sh

--- a/scripts/build-and-publish-worker-dood.sh
+++ b/scripts/build-and-publish-worker-dood.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# AVOID INVOKING THIS SCRIPT DIRECTLY -- USE `drake run build-and-publish-worker-dood`
+
+set -euo pipefail
+
+source scripts/versioning.sh
+source scripts/base-docker.sh
+
+scripts/docker-build.sh
+scripts/docker-publish.sh

--- a/scripts/build-worker-binary.sh
+++ b/scripts/build-worker-binary.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 source scripts/versioning.sh
 
 base_package_name=github.com/lovethedrake/brigdrake
-ldflags="-w -X $base_package_name/pkg/version.version=$rel_version -X $base_package_name/pkg/version.commit=$git_version"
+ldflags="-w -X $base_package_name/pkg/version.version=$REL_VERSION -X $base_package_name/pkg/version.commit=$GIT_VERSION"
 
 set -x
 

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -2,8 +2,6 @@
 
 set -euox pipefail
 
-base_package_name=github.com/lovethedrake/brigdrake
-
 docker build \
   --build-arg VERSION=$rel_version \
   --build-arg COMMIT=$git_version \

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -3,8 +3,8 @@
 set -euox pipefail
 
 docker build \
-  --build-arg VERSION=$rel_version \
-  --build-arg COMMIT=$git_version \
-  -t $base_image_name:$git_version \
+  --build-arg VERSION=$REL_VERSION \
+  --build-arg COMMIT=$GIT_VERSION \
+  -t $BASE_IMAGE_NAME:$GIT_VERSION \
   .
-docker tag $base_image_name:$git_version $base_image_name:$rel_version
+docker tag $BASE_IMAGE_NAME:$GIT_VERSION $BASE_IMAGE_NAME:$REL_VERSION

--- a/scripts/docker-publish.sh
+++ b/scripts/docker-publish.sh
@@ -6,5 +6,5 @@ set +x # Don't let the value of $DOCKER_PASSWORD bleed into the logs!
 echo $DOCKER_PASSWORD | docker login $DOCKER_REGISTRY -u $DOCKER_USER --password-stdin
 set -x
 
-docker push $base_image_name:$git_version
-docker push $base_image_name:$rel_version
+docker push $BASE_IMAGE_NAME:$GIT_VERSION
+docker push $BASE_IMAGE_NAME:$REL_VERSION

--- a/scripts/docker-publish.sh
+++ b/scripts/docker-publish.sh
@@ -2,5 +2,9 @@
 
 set -euox pipefail
 
+set +x # Don't let the value of $DOCKER_PASSWORD bleed into the logs!
+echo $DOCKER_PASSWORD | docker login $DOCKER_REGISTRY -u $DOCKER_USER --password-stdin
+set -x
+
 docker push $base_image_name:$git_version
 docker push $base_image_name:$rel_version

--- a/scripts/publish-worker-binary.sh
+++ b/scripts/publish-worker-binary.sh
@@ -10,6 +10,6 @@ go get -u github.com/tcnksm/ghr
 
 set +x
 
-echo "Publishing binary for commit $full_git_version"
+echo "Publishing binary for commit $FULL_GIT_VERSION"
 
-ghr -t $GITHUB_TOKEN -u lovethedrake -r brigdrake -c $full_git_version -delete $rel_version /shared/bin/
+ghr -t $GITHUB_TOKEN -u lovethedrake -r brigdrake -c $FULL_GIT_VERSION -delete $REL_VERSION /shared/bin/

--- a/scripts/versioning.sh
+++ b/scripts/versioning.sh
@@ -2,17 +2,17 @@
 
 set -euo pipefail
 
-export full_git_version=$(git rev-parse HEAD)
-export git_version=$(git describe --always --abbrev=7 --dirty --match=NeVeRmAtCh)
-rel_version=$(git tag --list 'v*' --points-at HEAD | tail -n 1)
+export FULL_GIT_VERSION=$(git rev-parse HEAD)
+export GIT_VERSION=$(git describe --always --abbrev=7 --dirty --match=NeVeRmAtCh)
+REL_VERSION=$(git tag --list 'v*' --points-at HEAD | tail -n 1)
 
-if [ "$rel_version" == "" ]; then
+if [ "$REL_VERSION" == "" ]; then
   git_branch=$(git rev-parse --abbrev-ref HEAD)
   if [ "$git_branch" == "master" ]; then
-    rel_version=edge
+    REL_VERSION=edge
   else
-    rel_version=unstable
+    REL_VERSION=unstable
   fi
 fi
 
-export rel_version
+export REL_VERSION


### PR DESCRIPTION
Build a worker with dood and then publish it to a registry on pushes to our default branch.

For now I'm publishing to https://github.com/orgs/lovethedrake/packages/container/brigdrake-worker/versions. One because of the docker hub changes to the free plan last year and also so that we don't publish anywhere official until we are ready.
